### PR TITLE
Running app on docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM openjdk:11-jdk-slim
+
+ENV LC_ALL C.UTF-8
+ENV LANG C.UTF-8
+
+# Install dependencies
+RUN apt-get update && apt-get install -y net-tools \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+# Create the application direcotry
+RUN set -ex && mkdir -p /app
+WORKDIR /app
+
+# Copy entrypoint.sh
+COPY ./docker-entrypoint.sh /app/docker-entrypoint.sh
+
+EXPOSE 80
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,5 +2,15 @@ version: '3'
 services:
   redis:
     image: "redis:alpine"
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./:/app
     ports:
-      - "6379:6379"
+      - "8080:8080"
+    depends_on:
+      - redis
+    command: /bin/bash /app/docker-entrypoint.sh

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# docker-entrypoint.sh
+#
+set -e
+
+PROJ_DIR=/app
+cd ${PROJ_DIR}
+
+# setup hosts
+netstat -nr | grep '^0\.0\.0\.0' | awk '{print $2" dockerhost"}' >> /etc/hosts
+
+# Build application
+./gradlew clean build
+
+# Run the application.
+java -jar ./build/libs/*.jar
+

--- a/src/main/kotlin/sample/adapter/infrastructure/spring/RedisConfiguration.kt
+++ b/src/main/kotlin/sample/adapter/infrastructure/spring/RedisConfiguration.kt
@@ -12,9 +12,4 @@ class RedisConfiguration {
     fun configureRedisAction(): ConfigureRedisAction {
         return ConfigureRedisAction.NO_OP
     }
-
-    @Bean
-    fun lettuceConnectionFactory(): LettuceConnectionFactory {
-        return LettuceConnectionFactory()
-    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,9 @@ server:
     session:
       timeout: 24h
 spring:
+  redis:
+    host: redis
+    port: 6379
   session:
     redis:
       namespace: oauth2-client-sample:session


### PR DESCRIPTION
Make it possible to run the application on docker-compose for easy to verification sample.

- Add Dockerfile for application
- Update docker-compose.yml to make the application work
- Remove lettuceConnectionFactory from RedisConfiguration.kt
    - LettuceConnectionFacctory's parameter-less constructor ignore configration values for spring.redis (host, port).  if not define a connection factory, Spring will automatically setup it
with configuration values.
    - so, remove func and to allow for more flexibility in configurations.

if you need to run only redis, you can `docker-compose run -d redis`.
